### PR TITLE
Add user-signature service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,13 @@
         "@ledgerhq/hw-transport-webhid": "^5.51.1",
         "@ledgerhq/hw-transport-webusb": "^5.49.0",
         "@onflow/encode": "0.0.8",
-        "@onflow/fcl": "^0.0.77",
+        "@onflow/fcl": "0.0.77",
         "@onflow/ledger": "^0.1.0",
         "@onflow/types": "^0.0.4",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.3.2",
         "@testing-library/user-event": "^7.1.2",
+        "is-promise": "^4.0.0",
         "node-sass": "^4.14.1",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -4139,7 +4140,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -8584,6 +8584,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
     "node_modules/is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -9011,7 +9016,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -13375,7 +13379,6 @@
         "eslint-plugin-react-hooks": "^1.6.1",
         "file-loader": "4.3.0",
         "fs-extra": "^8.1.0",
-        "fsevents": "2.1.2",
         "html-webpack-plugin": "4.0.0-beta.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "24.9.0",
@@ -16299,8 +16302,7 @@
       "dependencies": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "watchpack-chokidar2": "^2.0.0"
@@ -16546,7 +16548,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -24603,6 +24604,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "is-regex": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "styled-components": "^5.1.1"
   },
   "scripts": {
-    "start": "REACT_APP_DEBUG=true react-scripts start",
+    "start:testnet": "REACT_APP_WALLET_API_HOST=https://hardware-wallet-api-testnet.staging.onflow.org PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "build-emulator": "REACT_APP_DEBUG=true REACT_APP_EMULATOR_HOST=https://ledger-demo-emulator-http.staging.onflow.org REACT_APP_WALLET_API_HOST=https://hardware-wallet-api-emulator.staging.onflow.org react-scripts build",
     "build-testnet": "REACT_APP_DEBUG=true REACT_APP_WALLET_API_HOST=https://hardware-wallet-api-testnet.staging.onflow.org react-scripts build",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "is-promise": "^4.0.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import {FaTimes} from "react-icons/fa"
 import {Authn} from "./pages/authn.comp"
 import {Authz} from "./pages/authz.comp"
 import {ShowKey} from "./pages/showkey.comp"
+import {SignUserMessage} from "./pages/signUserMessage"
 
 window.fcl = fcl
 window.types = types
@@ -107,6 +108,50 @@ ReactDOM.render(
             <Route path="/canarynet/authz" component={props => <Authz {...props} network={NETWORKS.CANARYNET} debug={DEBUG} />} exact />
             <Route path="/testnet/authz" component={props => <Authz {...props} network={NETWORKS.TESTNET} debug={DEBUG} />} exact />
             <Route path="/mainnet/authz" component={props => <Authz {...props} network={NETWORKS.MAINNET} debug={DEBUG} />} exact />
+            <Route
+              path="/local/user-signature"
+              component={(props) => (
+                <SignUserMessage
+                  {...props}
+                  network={NETWORKS.LOCAL}
+                  debug={DEBUG}
+                />
+              )}
+              exact
+            />
+            <Route
+              path="/canarynet/user-signature"
+              component={(props) => (
+                <SignUserMessage
+                  {...props}
+                  network={NETWORKS.CANARYNET}
+                  debug={DEBUG}
+                />
+              )}
+              exact
+            />
+            <Route
+              path="/testnet/user-signature"
+              component={(props) => (
+                <SignUserMessage
+                  {...props}
+                  network={NETWORKS.TESTNET}
+                  debug={DEBUG}
+                />
+              )}
+              exact
+            />
+            <Route
+              path="/mainnet/user-signature"
+              component={(props) => (
+                <SignUserMessage
+                  {...props}
+                  network={NETWORKS.MAINNET}
+                  debug={DEBUG}
+                />
+              )}
+              exact
+            />
             <Route component={FourOhFour} />
           </Switch>
         </Inner>

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -267,6 +267,48 @@ export const signTransaction = async (tx, path = LEGACY_PATH_ADDRESS, cryptoOpti
     return convertToRawSignature(signature);
 };
 
+// NOTE: same code as for signTransaction just calling a different ledger method
+export const signUserMessage = async (
+  message,
+  path = LEGACY_PATH_ADDRESS,
+  cryptoOptions = 0x0201
+) => {
+  log("Ledger.signMessage");
+  const transport = await getTransport();
+  if (!transport) return;
+
+  let signature;
+
+  try {
+    const app = new FlowApp(transport);
+
+    let version = await app.getVersion();
+    log(`App Version ${version.major}.${version.minor}.${version.patch}`);
+    log(`Device Locked: ${version.deviceLocked}`);
+    log(`Test mode: ${version.testMode}`);
+
+    // NOTE: removed hex to buffer conversion since ledger expects hex string
+    log("Sending Request..");
+    const msgBuffer = Buffer.from(message.message, 'hex')
+    const response = await app.signMessage(path, msgBuffer, cryptoOptions)
+    log('Sign response: ', response);
+    if (response.returnCode !== FlowApp.ErrorCode.NoError) {
+        console.error(`Error [${response.returnCode}] ${response.errorMessage}`);
+        return;
+    }
+
+    log("Response received!");
+    log("Full response:");
+    log(response);
+
+    signature = response.signatureCompact;
+  } finally {
+    if (transport) transport.close();
+  }
+
+  return convertToRawSignature(signature);
+};
+
 // remove leading byte from public key
 const convertToRawPublicKey = (publicKey) => publicKey.slice(1).toString("hex");
 

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -289,13 +289,12 @@ export const signUserMessage = async (
 
     // NOTE: removed hex to buffer conversion since ledger expects hex string
     log("Sending Request..");
-    const msgBuffer = Buffer.from(message.message, 'hex')
-    const response = await app.signMessage(path, msgBuffer, cryptoOptions)
+    const response = {signatureCompact: Buffer.from("deadbeafff")}
     log('Sign response: ', response);
-    if (response.returnCode !== FlowApp.ErrorCode.NoError) {
-        console.error(`Error [${response.returnCode}] ${response.errorMessage}`);
-        return;
-    }
+    // if (response.returnCode !== FlowApp.ErrorCode.NoError) {
+    //     console.error(`Error [${response.returnCode}] ${response.errorMessage}`);
+    //     return;
+    // }
 
     log("Response received!");
     log("Full response:");

--- a/src/pages/authn.comp.js
+++ b/src/pages/authn.comp.js
@@ -87,6 +87,25 @@ export const Authn = ({ network = "local" }) => {
                 {
                   f_type: "Service",
                   f_vsn: "1.0.0",
+                  // taken from https://github.com/onflow/fcl-js/blob/b1aef3b393c2744a8c47839cc953cd4e71686274/packages/fcl/src/current-user/index.js#L327
+                  type: "user-signature",
+                  method: "IFRAME/RPC",
+                  uid: "fcl-ledger-user-message",
+                  endpoint: `${window.location.origin}/${network}/user-signature`,
+                  identity: {
+                    f_type: "Identity",
+                    f_vsn: "1.0.0",
+                    address: fcl.withPrefix(address),
+                    keyId: keyId,
+                  },
+                  data: {},
+                  params: {
+                    address: fcl.withPrefix(address),
+                  },
+                },
+                {
+                  f_type: "Service",
+                  f_vsn: "1.0.0",
                   type: "authn",
                   method: "DATA",
                   uid: "fcl-ledger-authn",

--- a/src/pages/signUserMessage.js
+++ b/src/pages/signUserMessage.js
@@ -1,0 +1,156 @@
+// NOTE: very much copy-pasted from ./authz.comp.js
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import * as fcl from "@onflow/fcl";
+import { signUserMessage } from "../ledger/ledger.js";
+import { getKeyIdForKeyByAccountAddress } from "../flow/accounts.js";
+import LedgerDevice from "../components/LedgerDevice";
+
+const StyledContainer = styled.div`
+  min-height: 20rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledMessageWrapper = styled.div`
+  width: 100%;
+  font-size: 1rem;
+  text-align: center;
+`;
+
+const StyledMessage = styled.div`
+  min-height: 4rem;
+`;
+
+const StyledAlertMessage = styled.div`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  min-height: 3rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  text-align: center;
+  color: white;
+  background-color: #fc4c2e;
+  box-sizing: border-box;
+`;
+
+const StyledErrorMesssage = styled.div`
+  padding: 1rem;
+  border-radius: 0.5rem;
+  text-align: center;
+  color: white;
+  background-color: #fc4c2e;
+  box-sizing: border-box;
+`;
+
+const DEFAULT_MESSAGE =
+  "Please connect and unlock your Ledger device, open the Flow app and then press start.";
+const ADDRESS_MISMATCH_MESSAGE = (
+  <StyledErrorMesssage>
+    The Flow account saved to your Ledger device does not match the account that
+    is expected by the transaction.
+    <br />
+    <br />
+    Please ensure the passphrase you used to unlock your Ledger is the same as
+    the one used when authenticating with this application and try again.
+  </StyledErrorMesssage>
+);
+
+export const SignUserMessage = ({ location, network = "local" }) => {
+  const [signable, setSignable] = useState("");
+  const [message, setMessage] = useState("");
+  const [account, setAccount] = useState(null);
+
+  const qp = new URLSearchParams(location.search);
+  const authnAddress = qp.get("address");
+
+  const handleCancel = () => {
+    fcl.WalletUtils.close();
+  };
+
+  useEffect(() => {
+    const unmount = fcl.WalletUtils.onMessageFromFCL(
+      "FCL:VIEW:READY:RESPONSE",
+      (data) => {
+        const _signable = data.body;
+        setSignable(_signable);
+      }
+    );
+
+    fcl.WalletUtils.sendMsgToFCL("FCL:VIEW:READY");
+
+    return unmount;
+  }, []);
+
+  useEffect(() => {
+    (async function getAddress() {
+      if (!signable) return;
+      if (!account) return;
+
+      const { address, publicKey, path } = account;
+
+      console.log("PRE SIG => ", account);
+
+      if (!publicKey || !address) {
+        setMessage(DEFAULT_MESSAGE);
+        return;
+      }
+
+      setMessage("Please follow the instructions on your Ledger device.");
+
+      const keyId = await getKeyIdForKeyByAccountAddress(address, publicKey);
+
+      if (keyId === -1) {
+        setMessage(DEFAULT_MESSAGE);
+        return;
+      }
+
+      let signature;
+
+      if (signable) {
+        signature = await signUserMessage(signable, path, 0x0201);
+      }
+
+      if (!signature) {
+        fcl.WalletUtils.decline("Ledger device did not sign this message.");
+        setMessage(
+          "Please connect and unlock your Ledger device, open the Flow app and then press start."
+        );
+        return;
+      }
+
+      setMessage("Signature: " + signature);
+
+      fcl.WalletUtils.approve(
+        new fcl.WalletUtils.CompositeSignature(
+          fcl.withPrefix(address),
+          keyId,
+          signature
+        )
+      );
+    })();
+  }, [signable, account]);
+
+  return (
+    <StyledContainer>
+      {process.env.REACT_APP_ALERT_MESSAGE && (
+        <StyledAlertMessage
+          dangerouslySetInnerHTML={{
+            __html: process.env.REACT_APP_ALERT_MESSAGE,
+          }}
+        />
+      )}
+      <LedgerDevice
+        account={account}
+        authnAddress={authnAddress}
+        network={network}
+        onGetAccount={setAccount}
+        handleCancel={handleCancel}
+      />
+      <StyledMessageWrapper>
+        {message && <StyledMessage>{message}</StyledMessage>}
+      </StyledMessageWrapper>
+    </StyledContainer>
+  );
+};


### PR DESCRIPTION
### Motivation
 - allow signing arbitrary messages with ledger through fcl
 
 ### Changes 

[Add user-signature service](https://github.com/PeterBenc/fork-fcl-ledger-web/pull/1/commits/75efb29d9a9c5a5a87e59bc1626b1ca5ae482b02)

  this commit has 4 parts, 
  1. Add signUserMessage to the list of services (here I very much reused the service config for authz)
  2. Add a ledger `signMessage` function, this one should call the ledger lib, check it out, as commented, its basically copy-pasted from the `signTransaction` function, with slight changes, here as well as in other parts, I didnt really tried to clean up the implementation and rather follow what guys from flow did for other ledger services
  3. Create a page for the user message signing, again, very much copy pasted from authz
  4. Add the signUserMessage to the routing
  
[Add is-promise package (drop if not needed)](https://github.com/PeterBenc/fork-fcl-ledger-web/pull/1/commits/f10b2eed0483694f7ce74d6b449d199c775c89de)
 - this might be only a local problem but without the package, I wasn't able to run the project
 

drop - start testnet locally
 - just util for testing

 
[drop - mock ledger signMessage call (for fcl testing only)](https://github.com/PeterBenc/fork-fcl-ledger-web/pull/1/commits/7bbf99ec5feb477dd969a87d8c7038b902614acf)
 - mock ledger message signing so we can test this without proper ledger app
  


### How to test

**Part 1.** (testing only the fcl integration)
 - for end to end testing you would need to get the updated ledger js lib and ledger firmware, so imho it makes sense to test the fcl integration first)

0. run `npm config set python "$PATH:/usr/local/bin/python"` (do this only if the yarn start command complains, I havent investigated this properly but this seemed to fix the issue)
1. run `yarn start:testnet` (this will run the ledger wallet service locally on port 3001)
2. Clone brud project (ping me for access or use some other app for testing),
3. checkout https://github.com/vacuumlabs/brud/tree/test-ledger-message-signing locally, (the discovery service is hard coded to the one you ran in step 1) 
4. run `yarn dev` (the config is currently set to testnet, if you had any problems with it you can try emulator I expect it to be a bit harder)
5. connect wallet and try signing a message (the response should be logged to console)

**Part 2.** (end to end testing with ledger)
 
1. build and replace npm version of ledger flow app js lib with https://github.com/onflow/ledger-app-flow/pull/101/commits/be078c11d748f2315ef2e3d61a2472ba2bcbbf78
2. from that same pr, you should be able to build the firmware as well, load it to the ledger
3. checkout [drop - start testnet locally](https://github.com/PeterBenc/fork-fcl-ledger-web/pull/1/commits/0c133afd2f45e5f965a09970543ba32c591081e8) ( this commit calls the actual function of the ledger app instead of mocking it)
4. continue from step 0 of part 1
 
 